### PR TITLE
Implement reports:revoke_share view

### DIFF
--- a/reports/templates/reports/share_report.html
+++ b/reports/templates/reports/share_report.html
@@ -108,8 +108,10 @@
                   <small class="text-muted">Shared {{ share.created_at|date:"N j, Y" }}</small>
                 </div>
               </div>
-              <!-- TODO: reports:revoke_share view needs to be added before enabling this button -->
-              <button type="button" class="btn btn-outline-danger btn-sm" disabled title="Revoke feature coming soon">Revoke</button>
+              <form method="post" action="{% url 'reports:revoke_share' share_pk=share.id %}">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-outline-danger btn-sm">Revoke</button>
+              </form>
             </div>
           </div>
           {% endfor %}

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path("change/<uuid:pk>/", views.request_change, name="request_change"),
     path("promote/<uuid:pk>/", views.promote_to_company, name="promote_to_company"),
     path("share/<uuid:pk>/", views.share_report, name="share_report"),
+    path("share/<uuid:share_pk>/revoke/", views.revoke_share, name="revoke_share"),
 
     # Admin queue
     path("admin/", views.admin_queue, name="admin_queue"),

--- a/reports/views.py
+++ b/reports/views.py
@@ -296,6 +296,18 @@ def share_report(request, pk):
 
 
 @login_required
+@require_POST
+def revoke_share(request, share_pk):
+    share = get_object_or_404(ReportShare, pk=share_pk)
+    if share.report.owner != request.user:
+        return HttpResponseForbidden("Not allowed")
+    report_pk = share.report.pk
+    share.delete()
+    messages.success(request, "Share revoked.")
+    return redirect("reports:share_report", pk=report_pk)
+
+
+@login_required
 @user_passes_test(_is_admin)
 def admin_queue(request):
     queue = (


### PR DESCRIPTION
Adds a POST endpoint that lets a report owner delete a ReportShare by
UUID. Wires up the URL, replaces the disabled "Revoke feature coming
soon" button in share_report.html with a real CSRF-protected form, and
removes the TODO comment.

https://claude.ai/code/session_013bdNV67gHFmyuSa4HkUB2c