### PR TITLE
Add full-column filtering to master log with left sidebar drawer

### DIFF
--- a/contracts/templates/contracts/contract_log_view.html
+++ b/contracts/templates/contracts/contract_log_view.html
@@ -4,7 +4,230 @@
 {% block title %}Contract Log View{% endblock %}
 
 {% block content %}
-<div class="container-fluid px-2 py-2" style="max-width: 1920px;">
+
+<!-- Sidebar backdrop (mobile) -->
+<div id="sidebarOverlay" class="fixed inset-0 bg-black/40 z-30 hidden"></div>
+
+<!-- Left filter sidebar -->
+<div id="filterSidebar"
+     class="fixed top-0 left-0 bottom-14 w-72 bg-white shadow-2xl z-40 flex flex-col
+            transform -translate-x-full transition-transform duration-300 ease-in-out">
+
+    <!-- Sidebar header -->
+    <div class="flex items-center justify-between px-4 py-3 border-b bg-gray-50 flex-shrink-0">
+        <span class="font-semibold text-sm text-gray-800">Filters</span>
+        <button id="closeSidebar" class="text-gray-400 hover:text-gray-700 transition-colors">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+        </button>
+    </div>
+
+    <!-- Scrollable filter groups -->
+    <div class="flex-1 overflow-y-auto p-3 space-y-3">
+
+        <!-- Group 1: Contract Identifiers -->
+        <fieldset class="border border-gray-200 rounded-md p-2">
+            <legend class="text-xs font-semibold text-gray-500 px-1">Contract Identifiers</legend>
+            <div class="space-y-2 mt-1">
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">PO #</label>
+                    <input id="f_po" type="text"
+                           class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                           value="{{ filter_po }}">
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">IDIQ Contract #</label>
+                    <input id="f_idiq" type="text"
+                           class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                           value="{{ filter_idiq }}">
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">Contract #</label>
+                    <input id="f_contract" type="text"
+                           class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                           value="{{ filter_contract }}">
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">CLIN #</label>
+                    <input id="f_clin" type="text"
+                           class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                           value="{{ filter_clin }}">
+                </div>
+            </div>
+        </fieldset>
+
+        <!-- Group 2: Contract Details -->
+        <fieldset class="border border-gray-200 rounded-md p-2">
+            <legend class="text-xs font-semibold text-gray-500 px-1">Contract Details</legend>
+            <div class="space-y-2 mt-1">
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">Status</label>
+                    <select id="f_status" class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500">
+                        <option value="">All Statuses</option>
+                        <option value="open" {% if status_filter == 'open' %}selected{% endif %}>Open</option>
+                        <option value="closed" {% if status_filter == 'closed' %}selected{% endif %}>Closed</option>
+                        <option value="canceled" {% if status_filter == 'canceled' or status_filter == 'cancelled' %}selected{% endif %}>Canceled</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">Buyer</label>
+                    <select id="f_buyer" class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500">
+                        <option value="">All Buyers</option>
+                        {% for b in buyers %}
+                            <option value="{{ b.id }}" {% if filter_buyer|stringformat:"s" == b.id|stringformat:"s" %}selected{% endif %}>{{ b.description }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">Contract Type</label>
+                    <select id="f_ctype" class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500">
+                        <option value="">All Types</option>
+                        {% for ct in contract_types %}
+                            <option value="{{ ct.id }}" {% if filter_ctype|stringformat:"s" == ct.id|stringformat:"s" %}selected{% endif %}>{{ ct.description }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">Supplier</label>
+                    <select id="f_supplier" class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500">
+                        <option value="">All Suppliers</option>
+                        {% for s in suppliers %}
+                            <option value="{{ s.id }}" {% if supplier_filter|stringformat:"s" == s.id|stringformat:"s" %}selected{% endif %}>{{ s.name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+            </div>
+        </fieldset>
+
+        <!-- Group 3: CLIN Info -->
+        <fieldset class="border border-gray-200 rounded-md p-2">
+            <legend class="text-xs font-semibold text-gray-500 px-1">CLIN Info</legend>
+            <div class="space-y-2 mt-1">
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">Search</label>
+                    <input id="f_search" type="text" placeholder="Contract#, PO#, NSN, supplier..."
+                           class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                           value="{{ search_query }}">
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">Cage Code</label>
+                    <input id="f_cage" type="text"
+                           class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                           value="{{ filter_cage }}">
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">NSN</label>
+                    <input id="f_nsn" type="text"
+                           class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                           value="{{ filter_nsn }}">
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">Item Description</label>
+                    <input id="f_desc" type="text"
+                           class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                           value="{{ filter_desc }}">
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">I&amp;A</label>
+                    <select id="f_ia" class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500">
+                        <option value="">All</option>
+                        <option value="O" {% if filter_ia == 'O' %}selected{% endif %}>Origin</option>
+                        <option value="D" {% if filter_ia == 'D' %}selected{% endif %}>Destination</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-700 mb-1">FOB</label>
+                    <select id="f_fob" class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500">
+                        <option value="">All</option>
+                        <option value="O" {% if filter_fob == 'O' %}selected{% endif %}>Origin</option>
+                        <option value="D" {% if filter_fob == 'D' %}selected{% endif %}>Destination</option>
+                    </select>
+                </div>
+            </div>
+        </fieldset>
+
+        <!-- Group 4: Dates -->
+        <fieldset class="border border-gray-200 rounded-md p-2">
+            <legend class="text-xs font-semibold text-gray-500 px-1">Dates</legend>
+            <div class="space-y-2 mt-1">
+                <p class="text-xs font-medium text-gray-600">Award Date</p>
+                <div class="grid grid-cols-2 gap-1">
+                    <div>
+                        <label class="block text-xs text-gray-500 mb-1">From</label>
+                        <input id="f_award_from" type="date"
+                               class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500"
+                               value="{{ filter_award_from }}">
+                    </div>
+                    <div>
+                        <label class="block text-xs text-gray-500 mb-1">To</label>
+                        <input id="f_award_to" type="date"
+                               class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500"
+                               value="{{ filter_award_to }}">
+                    </div>
+                </div>
+                <p class="text-xs font-medium text-gray-600">QDD (Supplier Due)</p>
+                <div class="grid grid-cols-2 gap-1">
+                    <div>
+                        <label class="block text-xs text-gray-500 mb-1">From</label>
+                        <input id="f_qdd_from" type="date"
+                               class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500"
+                               value="{{ filter_qdd_from }}">
+                    </div>
+                    <div>
+                        <label class="block text-xs text-gray-500 mb-1">To</label>
+                        <input id="f_qdd_to" type="date"
+                               class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500"
+                               value="{{ filter_qdd_to }}">
+                    </div>
+                </div>
+                <p class="text-xs font-medium text-gray-600">CDD (CLIN Due)</p>
+                <div class="grid grid-cols-2 gap-1">
+                    <div>
+                        <label class="block text-xs text-gray-500 mb-1">From</label>
+                        <input id="f_due_from" type="date"
+                               class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500"
+                               value="{{ filter_due_from }}">
+                    </div>
+                    <div>
+                        <label class="block text-xs text-gray-500 mb-1">To</label>
+                        <input id="f_due_to" type="date"
+                               class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500"
+                               value="{{ filter_due_to }}">
+                    </div>
+                </div>
+                <p class="text-xs font-medium text-gray-600">Ship Date</p>
+                <div class="grid grid-cols-2 gap-1">
+                    <div>
+                        <label class="block text-xs text-gray-500 mb-1">From</label>
+                        <input id="f_ship_from" type="date"
+                               class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500"
+                               value="{{ filter_ship_from }}">
+                    </div>
+                    <div>
+                        <label class="block text-xs text-gray-500 mb-1">To</label>
+                        <input id="f_ship_to" type="date"
+                               class="w-full border border-gray-300 rounded p-1 text-xs focus:ring-1 focus:ring-blue-500"
+                               value="{{ filter_ship_to }}">
+                    </div>
+                </div>
+            </div>
+        </fieldset>
+
+    </div><!-- end scrollable area -->
+
+    <!-- Sticky footer: Apply / Clear -->
+    <div class="p-3 border-t bg-gray-50 flex gap-2 flex-shrink-0">
+        <button id="applyFilters" class="btn-primary flex-1 text-sm py-1.5">Apply Filters</button>
+        <button id="clearFiltersBtn" class="btn-secondary text-sm py-1.5 px-3">Clear All</button>
+    </div>
+</div><!-- end sidebar -->
+
+<!-- ═══════════════════════════════════════════════════════════ -->
+<!-- Main content area (shifts right when sidebar is open on md+) -->
+<!-- ═══════════════════════════════════════════════════════════ -->
+<div id="mainContent" class="container-fluid px-2 py-2 transition-all duration-300" style="max-width: 1920px;">
+
     <!-- Loading Overlay -->
     <div id="loadingOverlay" class="fixed inset-0 modal-backdrop-overlay hidden flex items-center justify-center z-50">
         <div class="card card-padded max-w-md w-full">
@@ -29,16 +252,20 @@
             <h1 class="text-xl font-bold">Contract Log View</h1>
 
             <div class="flex items-center space-x-2">
-                <!-- Filter Toggle Button -->
-                <button id="toggleFilters" class="btn-secondary flex items-center text-sm">
+                <!-- Filter Sidebar Toggle -->
+                <button id="toggleSidebar" class="btn-secondary flex items-center text-sm relative">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-.293.707L13 13.414V19a1 1 0 01-.553.894l-4 2A1 1 0 017 21v-7.586L3.293 6.707A1 1 0 013 6V4z" />
                     </svg>
-                    Show Filters
+                    Filters
+                    <span id="activeFilterBadge"
+                          class="ml-1.5 hidden bg-blue-600 text-white text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center leading-none">
+                        0
+                    </span>
                 </button>
 
-                <!-- Clear Filters Button -->
-                <button id="clearFilters" class="btn-secondary flex items-center text-sm ">
+                <!-- Clear Filters -->
+                <button id="clearFilters" class="btn-secondary flex items-center text-sm">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                     </svg>
@@ -54,61 +281,18 @@
                 </button>
             </div>
         </div>
-
-        <!-- Filter Controls - Hidden by default -->
-        <div id="filterControls" class="mt-3 grid grid-cols-1 md:grid-cols-4 gap-2 hidden">
-            <div>
-                <label for="filterStatus" class="block text-xs font-medium text-gray-700 mb-1">Filter by Status</label>
-                <select id="filterStatus" class="w-full border border-gray-300 rounded-md shadow-sm p-1 text-sm">
-                    <option value="">All Statuses</option>
-                    <option value="open">Open</option>
-                    <option value="closed">Closed</option>
-                    <option value="canceled">Canceled</option>
-                </select>
-            </div>
-
-            <div>
-                <label for="filterSupplier" class="block text-xs font-medium text-gray-700 mb-1">Filter by Supplier</label>
-                <select id="filterSupplier" class="w-full border border-gray-300 rounded-md shadow-sm p-1 text-sm">
-                    <option value="">All Suppliers</option>
-                    {% for supplier in suppliers %}
-                        <option value="{{ supplier.id }}" {% if supplier.id|stringformat:"s" == request.GET.supplier %}selected{% endif %}>
-                            {{ supplier.name }}
-                        </option>
-                    {% endfor %}
-                </select>
-            </div>
-
-            <div>
-                <label for="searchContract" class="block text-xs font-medium text-gray-700 mb-1">Search Contracts</label>
-                <input type="text" id="searchContract" placeholder="Search by contract number, last 4 digits, or PO..."
-                       class="w-full border border-gray-300 rounded-md shadow-sm p-1 text-sm">
-            </div>
-
-            <div class="flex items-end">
-                <button id="applyFilters" class="btn-secondary text-sm py-1">
-                    Apply Filters
-                </button>
-            </div>
-        </div>
     </div>
 
     <!-- Contract Table -->
     <div class="card overflow-hidden">
         <div class="overflow-x-auto">
             <table class="w-full whitespace-nowrap">
-                    <thead class="bg-gray-50 sticky top-0 z-10">
+                <thead class="bg-gray-50 sticky top-0 z-10">
                     <tr class="label text-left">
                         <th class="px-1.5 py-1">Status</th>
-                        <th class="px-2 py-1 text-left label whitespace-nowrap">
-                            PO #
-                        </th>
-                        <th class="px-2 py-1 text-left label whitespace-nowrap">
-                            IDIQ Contract #
-                        </th>
-                        <th class="px-2 py-1 text-left label whitespace-nowrap">
-                            Contract #
-                        </th>
+                        <th class="px-2 py-1 text-left label whitespace-nowrap">PO #</th>
+                        <th class="px-2 py-1 text-left label whitespace-nowrap">IDIQ Contract #</th>
+                        <th class="px-2 py-1 text-left label whitespace-nowrap">Contract #</th>
                         <th class="px-1.5 py-1">Buyer</th>
                         <th class="px-1.5 py-1">Type</th>
                         <th class="px-1.5 py-1">CLIN #</th>
@@ -125,12 +309,12 @@
                         <th class="px-1.5 py-1">FOB</th>
                         <th class="px-1.5 py-1">Target Ship Date</th>
                         <th class="px-1.5 py-1">CLIN Due Date</th>
-                        <th class="px-1.5 py-1">Order Qty</th>
+                        <th class="px-1.5 py-1">Qty / UOM</th>
                         <th class="px-1.5 py-1">Ship Date</th>
                         <th class="px-1.5 py-1">Ship Qty</th>
                         <th class="px-1.5 py-1">Sub PO $</th>
                         <th class="px-1.5 py-1">Sub Paid $</th>
-                        <th class="px-1.5 py-1">X</th>
+                        <th class="px-1.5 py-1">Item Value</th>
                         <th class="px-1.5 py-1">Contract $</th>
                         <th class="px-1.5 py-1">Customer Payment $</th>
                         <th class="px-1.5 py-1">Date Pay Recv</th>
@@ -138,385 +322,425 @@
                         <th class="px-1.5 py-1">Actual Paid PPI $</th>
                         <th class="px-1.5 py-1">Actual STATZ $</th>
                         <th class="px-1.5 py-1">Notes</th>
-                        </tr>
-                    </thead>
-                    <tbody class="bg-white divide-y divide-gray-200">
-                    {% for clin in clins %}
-                    <tr class="hover:bg-gray-50 text-xs">
-                        <td class="px-1.5 py-1">
-                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
-                                              {% if clin.contract.status.description == 'Canceled' %}bg-red-100 text-red-800
-                                              {% elif clin.contract.date_closed %}bg-yellow-100 text-yellow-800
-                                              {% else %}bg-green-100 text-green-800{% endif %}">
-                                            {% if clin.contract.status.description == 'Canceled' %}Canceled
-                                            {% elif clin.contract.date_closed %}Closed
-                                            {% else %}Open{% endif %}
-                                </span>
-                            </td>
-                        <td class="px-2 py-1 whitespace-nowrap text-sm text-gray-900">
-                            {{ clin.contract.po_number }}
-                        </td>
-                        <td class="px-2 py-1 whitespace-nowrap text-sm text-gray-900">
-                            {{ clin.contract.idiq_contract.contract_number|default:'' }}
-                        </td>
-                        <td class="px-2 py-1 whitespace-nowrap text-sm text-gray-900">
-                            <a href="{% url 'contracts:contract_management' clin.contract.id %}"
-                               class="text-blue-600 hover:text-blue-800">
-                                {{ clin.contract.contract_number }}
-                            </a>
-                        </td>
-                        <td class="px-1.5 py-1">{{ clin.contract.buyer.description }}</td>
-                        <td class="px-1.5 py-1">{{ clin.contract.contract_type.description }}</td>
-                        <td class="px-1.5 py-1">{{ clin.item_number }}</td>
-                        <td class="px-1.5 py-1">
-                            <a href="{% url 'suppliers:supplier_detail' clin.supplier.id %}"
-                               class="text-blue-600 hover:text-blue-800">
-                                {{ clin.supplier.name }}
-                            </a>
-                        </td>
-                        <td class="px-1.5 py-1">{{ clin.supplier.cage_code|default:"" }}</td>
-                        <td class="px-1.5 py-1">{{ clin.contract.award_date|date:"m/d/Y"|default:"-" }}</td>
-                        <td class="px-1.5 py-1">{{ clin.contract_status_text|default:"" }}</td>
-                        <td class="px-1.5 py-1">
-                            <a href="{% url 'contracts:nsn_edit' clin.nsn.id %}"
-                               class="text-blue-600 hover:text-blue-800">
-                               {{ clin.nsn.nsn_code|default:"" }}
-                            </a>
-                        </td>
-                        <td class="px-1.5 py-1">{{ clin.nsn.description|default:"" }}</td>
-                        <td class="px-1.5 py-1">{{ clin.ia|default:"" }}</td>
-                        <td class="px-1.5 py-1">{% if clin.clinacknowledgment_set.first.po_to_supplier_bool %}Yes{% else %}No{% endif %}</td>
-                        <td class="px-1.5 py-1">{% if clin.clinacknowledgment_set.first.clin_reply_bool %}Yes{% else %}No{% endif %}</td>
-                        <td class="px-1.5 py-1">{% if clin.clinacknowledgment_set.first.po_to_qar_bool %}Yes{% else %}No{% endif %}</td>
-                        <td class="px-1.5 py-1">{{ clin.fob|default:"" }}</td>
-                        <td class="px-1.5 py-1">{{ clin.supplier_due_date|date:"m/d/Y" }}</td>
-                        <td class="px-1.5 py-1">{{ clin.due_date|date:"m/d/Y"|default:"-" }}</td>
-                        <td class="px-1.5 py-1">{{ clin.order_qty|default:"0" }} {{ clin.uom|default:"ea" }}</td>
-                        <td class="px-1.5 py-1">{{ clin.ship_date|date:"m/d/Y"|default:"-" }}</td>
-                        <td class="px-1.5 py-1">{{ clin.ship_qty|default:"-" }}</td>
-                        <td class="px-1.5 py-1">${{ clin.quote_value|floatformat:2|default:"0.00" }}</td>
-                        <td class="px-1.5 py-1">${{ clin.paid_amount|floatformat:2|default:"0.00" }}</td>
-                        <td class="px-1.5 py-1"></td>
-                        <td class="px-1.5 py-1">${{ clin.contract.contract_value|floatformat:2|default:"0.00" }}</td>
-                        <td class="px-1.5 py-1">${{ clin.wawf_payment|floatformat:2|default:"0.00" }}</td>
-                        <td class="px-1.5 py-1">{{ clin.wawf_recieved|date:"m/d/Y"|default:"-" }}</td>
-                        <td class="px-1.5 py-1">
-                            {% if clin.is_first_for_contract %}
-                                ${{ clin.contract.plan_gross|floatformat:2|default:"0.00" }}
-                            {% else %}
-                                $0.00
-                            {% endif %}
-                        </td>
-                        <td class="px-1.5 py-1">
-                            {% if clin.is_first_for_contract %}
-                                ${{ clin.ppi_split_paid|floatformat:2|default:"0.00" }}
-                            {% else %}
-                                $0.00
-                            {% endif %}
-                        </td>
-                        <td class="px-1.5 py-1">
-                            {% if clin.is_first_for_contract %}
-                                ${{ clin.statz_split_paid|floatformat:2|default:"0.00" }}
-                            {% else %}
-                                $0.00
-                            {% endif %}
-                        </td>
-                        <td class="px-1.5 py-1"></td>
-                        </tr>
-                        {% empty %}
-                        <tr>
-                        <td colspan="33" class="px-1.5 py-1 text-center text-gray-500">
-                            No records found
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                {% for clin in clins %}
+                <tr class="hover:bg-gray-50 text-xs">
+                    <td class="px-1.5 py-1">
+                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
+                                      {% if clin.contract.status.description == 'Canceled' %}bg-red-100 text-red-800
+                                      {% elif clin.contract.date_closed %}bg-yellow-100 text-yellow-800
+                                      {% else %}bg-green-100 text-green-800{% endif %}">
+                            {% if clin.contract.status.description == 'Canceled' %}Canceled
+                            {% elif clin.contract.date_closed %}Closed
+                            {% else %}Open{% endif %}
+                        </span>
+                    </td>
+                    <td class="px-2 py-1 whitespace-nowrap text-sm text-gray-900">
+                        {{ clin.contract.po_number }}
+                    </td>
+                    <td class="px-2 py-1 whitespace-nowrap text-sm text-gray-900">
+                        {{ clin.contract.idiq_contract.contract_number|default:'' }}
+                    </td>
+                    <td class="px-2 py-1 whitespace-nowrap text-sm text-gray-900">
+                        <a href="{% url 'contracts:contract_management' clin.contract.id %}"
+                           class="text-blue-600 hover:text-blue-800">
+                            {{ clin.contract.contract_number }}
+                        </a>
+                    </td>
+                    <td class="px-1.5 py-1">{{ clin.contract.buyer.description }}</td>
+                    <td class="px-1.5 py-1">{{ clin.contract.contract_type.description }}</td>
+                    <td class="px-1.5 py-1">{{ clin.item_number }}</td>
+                    <td class="px-1.5 py-1">
+                        <a href="{% url 'suppliers:supplier_detail' clin.supplier.id %}"
+                           class="text-blue-600 hover:text-blue-800">
+                            {{ clin.supplier.name }}
+                        </a>
+                    </td>
+                    <td class="px-1.5 py-1">{{ clin.supplier.cage_code|default:"" }}</td>
+                    <td class="px-1.5 py-1">{{ clin.contract.award_date|date:"m/d/Y"|default:"-" }}</td>
+                    <td class="px-1.5 py-1">{{ clin.contract_status_text|default:"" }}</td>
+                    <td class="px-1.5 py-1">
+                        <a href="{% url 'contracts:nsn_edit' clin.nsn.id %}"
+                           class="text-blue-600 hover:text-blue-800">
+                           {{ clin.nsn.nsn_code|default:"" }}
+                        </a>
+                    </td>
+                    <td class="px-1.5 py-1">{{ clin.nsn.description|default:"" }}</td>
+                    <td class="px-1.5 py-1">{{ clin.ia|default:"" }}</td>
+                    <td class="px-1.5 py-1">{% if clin.clinacknowledgment_set.first.po_to_supplier_bool %}Yes{% else %}No{% endif %}</td>
+                    <td class="px-1.5 py-1">{% if clin.clinacknowledgment_set.first.clin_reply_bool %}Yes{% else %}No{% endif %}</td>
+                    <td class="px-1.5 py-1">{% if clin.clinacknowledgment_set.first.po_to_qar_bool %}Yes{% else %}No{% endif %}</td>
+                    <td class="px-1.5 py-1">{{ clin.fob|default:"" }}</td>
+                    <td class="px-1.5 py-1">{{ clin.supplier_due_date|date:"m/d/Y" }}</td>
+                    <td class="px-1.5 py-1">{{ clin.due_date|date:"m/d/Y"|default:"-" }}</td>
+                    <td class="px-1.5 py-1">{{ clin.order_qty|default:"0" }} {{ clin.uom|default:"ea" }}</td>
+                    <td class="px-1.5 py-1">{{ clin.ship_date|date:"m/d/Y"|default:"-" }}</td>
+                    <td class="px-1.5 py-1">{{ clin.ship_qty|default:"-" }}</td>
+                    <td class="px-1.5 py-1">${{ clin.quote_value|floatformat:2|default:"0.00" }}</td>
+                    <td class="px-1.5 py-1">${{ clin.paid_amount|floatformat:2|default:"0.00" }}</td>
+                    <td class="px-1.5 py-1">${{ clin.item_value|floatformat:2|default:"0.00" }}</td>
+                    <td class="px-1.5 py-1">
+                        {% if clin.is_first_for_contract %}
+                            ${{ clin.contract.contract_value|floatformat:2|default:"0.00" }}
+                        {% else %}
+                            $0.00
+                        {% endif %}
+                    </td>
+                    <td class="px-1.5 py-1">${{ clin.wawf_payment|floatformat:2|default:"0.00" }}</td>
+                    <td class="px-1.5 py-1">{{ clin.wawf_recieved|date:"m/d/Y"|default:"-" }}</td>
+                    <td class="px-1.5 py-1">
+                        {% if clin.is_first_for_contract %}
+                            ${{ clin.contract.plan_gross|floatformat:2|default:"0.00" }}
+                        {% else %}
+                            $0.00
+                        {% endif %}
+                    </td>
+                    <td class="px-1.5 py-1">
+                        {% if clin.is_first_for_contract %}
+                            ${{ clin.ppi_split_paid|floatformat:2|default:"0.00" }}
+                        {% else %}
+                            $0.00
+                        {% endif %}
+                    </td>
+                    <td class="px-1.5 py-1">
+                        {% if clin.is_first_for_contract %}
+                            ${{ clin.statz_split_paid|floatformat:2|default:"0.00" }}
+                        {% else %}
+                            $0.00
+                        {% endif %}
+                    </td>
+                    <td class="px-1.5 py-1"></td>
+                </tr>
+                {% empty %}
+                <tr>
+                    <td colspan="33" class="px-1.5 py-4 text-center text-gray-500">
+                        No records found
+                    </td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
         </div>
+    </div>
 
     <!-- Pagination -->
-        {% if is_paginated %}
-        <div class="card mt-2 px-4 py-2" data-pagination-base="{% if pagination_query_string %}{{ pagination_query_string }}{% endif %}" data-num-pages="{{ paginator.num_pages }}">
-            <div class="flex flex-col items-center justify-center space-y-2">
-                <div class="bg-blue-700 text-white rounded-md p-1 pr-4 pl-4">
-                    <nav class="relative z-0 inline-flex flex-wrap rounded-md shadow-sm items-center gap-x-2 gap-y-1">
-                        <!-- First Page -->
-                        {% if page_obj.has_previous %}
-                            <a href="?page=1{% if pagination_query_string %}&{{ pagination_query_string }}{% endif %}"
-                               class="btn-pagination underline">First</a>
-                        {% else %}
-                            <span class="btn-pagination opacity-50 cursor-not-allowed">First</span>
-                        {% endif %}
+    {% if is_paginated %}
+    <div class="card mt-2 px-4 py-2" data-pagination-base="{% if pagination_query_string %}{{ pagination_query_string }}{% endif %}" data-num-pages="{{ paginator.num_pages }}">
+        <div class="flex flex-col items-center justify-center space-y-2">
+            <div class="bg-blue-700 text-white rounded-md p-1 pr-4 pl-4">
+                <nav class="relative z-0 inline-flex flex-wrap rounded-md shadow-sm items-center gap-x-2 gap-y-1">
+                    {% if page_obj.has_previous %}
+                        <a href="?page=1{% if pagination_query_string %}&{{ pagination_query_string }}{% endif %}"
+                           class="btn-pagination underline">First</a>
+                    {% else %}
+                        <span class="btn-pagination opacity-50 cursor-not-allowed">First</span>
+                    {% endif %}
 
-                        <!-- Previous Page -->
-                        {% if page_obj.has_previous %}
-                            <a href="?page={{ page_obj.previous_page_number }}{% if pagination_query_string %}&{{ pagination_query_string }}{% endif %}"
-                               class="btn-pagination underline">Prev</a>
-                        {% else %}
-                            <span class="btn-pagination opacity-50 cursor-not-allowed">Prev</span>
-                        {% endif %}
+                    {% if page_obj.has_previous %}
+                        <a href="?page={{ page_obj.previous_page_number }}{% if pagination_query_string %}&{{ pagination_query_string }}{% endif %}"
+                           class="btn-pagination underline">Prev</a>
+                    {% else %}
+                        <span class="btn-pagination opacity-50 cursor-not-allowed">Prev</span>
+                    {% endif %}
 
-                        <!-- Page Range -->
-                        {% for i in paginator.page_range %}
-                            {% if i >= page_obj.number|add:"-3" and i <= page_obj.number|add:"3" %}
-                                {% if page_obj.number == i %}
-                                    <span class="btn-pagination-active mx-1">{{ i }}</span>
-                                {% else %}
-                                    <a href="?page={{ i }}{% if pagination_query_string %}&{{ pagination_query_string }}{% endif %}"
-                                       class="btn-pagination mx-1 underline">{{ i }}</a>
-                                {% endif %}
+                    {% for i in paginator.page_range %}
+                        {% if i >= page_obj.number|add:"-3" and i <= page_obj.number|add:"3" %}
+                            {% if page_obj.number == i %}
+                                <span class="btn-pagination-active mx-1">{{ i }}</span>
+                            {% else %}
+                                <a href="?page={{ i }}{% if pagination_query_string %}&{{ pagination_query_string }}{% endif %}"
+                                   class="btn-pagination mx-1 underline">{{ i }}</a>
                             {% endif %}
-                        {% endfor %}
-
-                        <!-- Next Page -->
-                        {% if page_obj.has_next %}
-                            <a href="?page={{ page_obj.next_page_number }}{% if pagination_query_string %}&{{ pagination_query_string }}{% endif %}"
-                               class="btn-pagination underline">Next</a>
-                        {% else %}
-                            <span class="btn-pagination opacity-50 cursor-not-allowed">Next</span>
                         {% endif %}
+                    {% endfor %}
 
-                        <!-- Last Page -->
-                        {% if page_obj.has_next %}
-                            <a href="?page={{ paginator.num_pages }}{% if pagination_query_string %}&{{ pagination_query_string }}{% endif %}"
-                               class="btn-pagination underline">Last</a>
-                        {% else %}
-                            <span class="btn-pagination opacity-50 cursor-not-allowed">Last</span>
-                        {% endif %}
+                    {% if page_obj.has_next %}
+                        <a href="?page={{ page_obj.next_page_number }}{% if pagination_query_string %}&{{ pagination_query_string }}{% endif %}"
+                           class="btn-pagination underline">Next</a>
+                    {% else %}
+                        <span class="btn-pagination opacity-50 cursor-not-allowed">Next</span>
+                    {% endif %}
 
-                        <!-- Jump to page -->
-                        <span class="ml-2 inline-flex items-center gap-1 text-white">
-                            <label for="jumpToPage" class="text-xs">Jump to</label>
-                            <input type="number" id="jumpToPage" min="1" max="{{ paginator.num_pages }}" value="{{ page_obj.number }}"
-                                   class="w-14 px-1 py-0.5 text-sm text-gray-900 rounded border border-gray-300">
-                            <button type="button" id="jumpToPageBtn" class="btn-pagination text-xs py-0.5 px-2 rounded">Go</button>
-                        </span>
+                    {% if page_obj.has_next %}
+                        <a href="?page={{ paginator.num_pages }}{% if pagination_query_string %}&{{ pagination_query_string }}{% endif %}"
+                           class="btn-pagination underline">Last</a>
+                    {% else %}
+                        <span class="btn-pagination opacity-50 cursor-not-allowed">Last</span>
+                    {% endif %}
 
-                        <!-- Per page selector -->
-                        <span class="ml-2 inline-flex items-center gap-1 text-white">
-                            <label for="perPageSelect" class="text-xs">Per page</label>
-                            <select id="perPageSelect" class="px-1 py-0.5 text-sm text-gray-900 rounded border border-gray-300 min-w-0">
-                                {% for n in allowed_per_page %}
-                                    <option value="{{ n }}" {% if current_per_page == n %}selected{% endif %}>{{ n }}</option>
-                                {% endfor %}
-                            </select>
-                        </span>
-                    </nav>
-                </div>
-                <div class="bg-blue-300 rounded-md p-1 flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
-                    <p class="text-sm text-black">
+                    <!-- Jump to page -->
+                    <span class="ml-2 inline-flex items-center gap-1 text-white">
+                        <label for="jumpToPage" class="text-xs">Jump to</label>
+                        <input type="number" id="jumpToPage" min="1" max="{{ paginator.num_pages }}" value="{{ page_obj.number }}"
+                               class="w-14 px-1 py-0.5 text-sm text-gray-900 rounded border border-gray-300">
+                        <button type="button" id="jumpToPageBtn" class="btn-pagination text-xs py-0.5 px-2 rounded">Go</button>
+                    </span>
+
+                    <!-- Per page selector -->
+                    <span class="ml-2 inline-flex items-center gap-1 text-white">
+                        <label for="perPageSelect" class="text-xs">Per page</label>
+                        <select id="perPageSelect" class="px-1 py-0.5 text-sm text-gray-900 rounded border border-gray-300 min-w-0">
+                            {% for n in allowed_per_page %}
+                                <option value="{{ n }}" {% if current_per_page == n %}selected{% endif %}>{{ n }}</option>
+                            {% endfor %}
+                        </select>
+                    </span>
+                </nav>
+            </div>
+            <div class="bg-blue-300 rounded-md p-1 flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
+                <p class="text-sm text-black">
                     Showing <span class="font-medium">{{ page_obj.start_index }}</span> to
                     <span class="font-medium">{{ page_obj.end_index }}</span> of
                     <span class="font-medium">{{ paginator.count }}</span> results
-                    </p>
-                </div>
+                </p>
             </div>
         </div>
-        {% endif %}
     </div>
+    {% endif %}
+
+</div><!-- end mainContent -->
 {% endblock %}
 
 {% block extra_scripts %}
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        // Filter toggle functionality
-        const toggleFilters = document.getElementById('toggleFilters');
-        const filterControls = document.getElementById('filterControls');
-        const loadingOverlay = document.getElementById('loadingOverlay');
-        const progressBar = document.getElementById('progressBar');
+document.addEventListener('DOMContentLoaded', function () {
 
-        toggleFilters.addEventListener('click', function() {
-            filterControls.classList.toggle('hidden');
-        });
+    // ── Sidebar open / close ─────────────────────────────────────────
+    const sidebar  = document.getElementById('filterSidebar');
+    const overlay  = document.getElementById('sidebarOverlay');
+    const mainContent = document.getElementById('mainContent');
 
-        // Apply filters
-        const applyFilters = document.getElementById('applyFilters');
-        const clearFilters = document.getElementById('clearFilters');
-        const filterStatus = document.getElementById('filterStatus');
-        const filterSupplier = document.getElementById('filterSupplier');
-        const searchContract = document.getElementById('searchContract');
+    function openSidebar() {
+        sidebar.classList.remove('-translate-x-full');
+        overlay.classList.remove('hidden');
+        mainContent.classList.add('md:pl-72');
+    }
+    function closeSidebar() {
+        sidebar.classList.add('-translate-x-full');
+        overlay.classList.add('hidden');
+        mainContent.classList.remove('md:pl-72');
+    }
 
-        // Set initial values from URL if they exist
+    document.getElementById('toggleSidebar').addEventListener('click', function () {
+        sidebar.classList.contains('-translate-x-full') ? openSidebar() : closeSidebar();
+    });
+    document.getElementById('closeSidebar').addEventListener('click', closeSidebar);
+    overlay.addEventListener('click', closeSidebar);
+
+    // ── Active-filter badge (counts applied URL params) ───────────────
+    const FILTER_PARAMS = [
+        'status', 'supplier', 'search', 'po', 'idiq', 'contract',
+        'buyer', 'ctype', 'clin', 'cage', 'nsn', 'desc', 'ia', 'fob',
+        'award_from', 'award_to', 'qdd_from', 'qdd_to',
+        'due_from', 'due_to', 'ship_from', 'ship_to'
+    ];
+
+    function updateBadge() {
         const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.has('status')) {
-            let st = urlParams.get('status');
-            if (st === 'cancelled') {
-                st = 'canceled';
+        const count = FILTER_PARAMS.filter(p => (urlParams.get(p) || '').trim()).length;
+        const badge = document.getElementById('activeFilterBadge');
+        badge.textContent = count;
+        badge.classList.toggle('hidden', count === 0);
+    }
+
+    // ── Map sidebar input IDs → GET param names ───────────────────────
+    const PARAM_MAP = {
+        'f_status':    'status',
+        'f_supplier':  'supplier',
+        'f_search':    'search',
+        'f_po':        'po',
+        'f_idiq':      'idiq',
+        'f_contract':  'contract',
+        'f_buyer':     'buyer',
+        'f_ctype':     'ctype',
+        'f_clin':      'clin',
+        'f_cage':      'cage',
+        'f_nsn':       'nsn',
+        'f_desc':      'desc',
+        'f_ia':        'ia',
+        'f_fob':       'fob',
+        'f_award_from':'award_from',
+        'f_award_to':  'award_to',
+        'f_qdd_from':  'qdd_from',
+        'f_qdd_to':    'qdd_to',
+        'f_due_from':  'due_from',
+        'f_due_to':    'due_to',
+        'f_ship_from': 'ship_from',
+        'f_ship_to':   'ship_to',
+    };
+
+    // ── Apply filters ─────────────────────────────────────────────────
+    function applyFilters() {
+        const params = new URLSearchParams();
+        for (const [id, param] of Object.entries(PARAM_MAP)) {
+            const el = document.getElementById(id);
+            if (el && el.value.trim()) {
+                params.set(param, el.value.trim());
             }
-            filterStatus.value = st;
         }
-        if (urlParams.has('supplier')) {
-            filterSupplier.value = urlParams.get('supplier');
-        }
-        if (urlParams.has('search')) {
-            searchContract.value = urlParams.get('search');
-        }
+        window.location.href = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+    }
 
-        applyFilters.addEventListener('click', function() {
-            const status = filterStatus.value;
-            const supplier = filterSupplier.value;
-            const search = searchContract.value;
-
-            let queryParams = [];
-            if (status) queryParams.push(`status=${status}`);
-            if (supplier) queryParams.push(`supplier=${supplier}`);
-            if (search) queryParams.push(`search=${search}`);
-
-            window.location.href = `${window.location.pathname}${queryParams.length ? '?' + queryParams.join('&') : ''}`;
+    // ── Clear all filters ─────────────────────────────────────────────
+    function clearAllFilters() {
+        Object.keys(PARAM_MAP).forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.value = '';
         });
+        window.location.href = window.location.pathname;
+    }
 
-        // Clear filters functionality
-        clearFilters.addEventListener('click', function() {
-            filterStatus.value = '';
-            filterSupplier.value = '';
-            searchContract.value = '';
-            window.location.href = window.location.pathname;
-        });
+    document.getElementById('applyFilters').addEventListener('click', applyFilters);
+    document.getElementById('clearFiltersBtn').addEventListener('click', clearAllFilters);
+    document.getElementById('clearFilters').addEventListener('click', clearAllFilters);
 
-        // Export functionality
-        const exportBtn = document.getElementById('exportBtn');
-
-        function updateExportProgress(progress, message) {
-            const progressBar = document.getElementById('progressBar');
-            const statusText = document.getElementById('exportStatus');
-            progressBar.style.width = `${progress}%`;
-            if (message) {
-                statusText.textContent = message;
-            }
+    // ── Pre-populate sidebar from current URL ─────────────────────────
+    const urlParams = new URLSearchParams(window.location.search);
+    for (const [id, param] of Object.entries(PARAM_MAP)) {
+        const el = document.getElementById(id);
+        if (el) {
+            let val = urlParams.get(param) || '';
+            if (param === 'status' && val === 'cancelled') val = 'canceled';
+            el.value = val;
         }
+    }
 
-        async function getExportEstimate(rowCount) {
-            try {
-                const response = await fetch(`{% url "contracts:get_export_estimate" %}?rows=${rowCount}`);
-                const data = await response.json();
-                return data;
-            } catch (error) {
-                console.error('Error getting export estimate:', error);
-                return null;
-            }
+    // Auto-open sidebar when any filter is active
+    updateBadge();
+    if (FILTER_PARAMS.some(p => (urlParams.get(p) || '').trim())) {
+        openSidebar();
+    }
+
+    // ── Export functionality ──────────────────────────────────────────
+    const exportBtn = document.getElementById('exportBtn');
+
+    function updateExportProgress(progress, message) {
+        document.getElementById('progressBar').style.width = `${progress}%`;
+        if (message) document.getElementById('exportStatus').textContent = message;
+    }
+
+    async function getExportEstimate(rowCount) {
+        try {
+            const r = await fetch(`{% url "contracts:get_export_estimate" %}?rows=${rowCount}`);
+            return await r.json();
+        } catch {
+            return null;
         }
+    }
 
-        function formatDateTime(isoString) {
-            const date = new Date(isoString);
-            return date.toLocaleString();
-        }
+    function formatDateTime(isoString) {
+        return new Date(isoString).toLocaleString();
+    }
 
-        async function exportContractLog() {
-            const startTime = performance.now();
-            const loadingOverlay = document.getElementById('loadingOverlay');
-            const exportStats = document.getElementById('exportStats');
-            const recentExports = document.getElementById('recentExports');
-            const exportTime = document.getElementById('exportTime');
+    async function exportContractLog() {
+        const startTime = performance.now();
+        const loadingOverlay = document.getElementById('loadingOverlay');
+        const exportStats   = document.getElementById('exportStats');
+        const recentExports = document.getElementById('recentExports');
+        const exportTime    = document.getElementById('exportTime');
 
-            loadingOverlay.classList.remove('hidden');
-            exportTime.textContent = '';
+        loadingOverlay.classList.remove('hidden');
+        exportTime.textContent = '';
 
-            try {
-                // Get row count from the table
-                const rowCount = document.querySelector('.text-sm.text-black')?.textContent.match(/of\s+(\d+)\s+results/)?.[1] || '0';
-                const numRows = parseInt(rowCount);
+        try {
+            const rowCount = document.querySelector('.text-sm.text-black')?.textContent.match(/of\s+([\d,]+)\s+results/)?.[1]?.replace(/,/g, '') || '0';
+            const numRows  = parseInt(rowCount);
 
-                // Get export estimate and recent timings
-                const estimateData = await getExportEstimate(numRows);
-                if (estimateData) {
-                    const { estimated_seconds, recent_timings } = estimateData;
+            const estimateData = await getExportEstimate(numRows);
+            if (estimateData) {
+                const { estimated_seconds, recent_timings } = estimateData;
 
-                    // Display recent export times
-                    recentExports.innerHTML = recent_timings.map(timing => `
-                        <li>${timing.row_count} rows in ${timing.export_time.toFixed(1)}s (${formatDateTime(timing.timestamp)})</li>
-                    `).join('');
-                    exportStats.classList.remove('hidden');
+                recentExports.innerHTML = recent_timings.map(t =>
+                    `<li>${t.row_count} rows in ${t.export_time.toFixed(1)}s (${formatDateTime(t.timestamp)})</li>`
+                ).join('');
+                exportStats.classList.remove('hidden');
 
-                    // Start progress updates
-                    let progress = 0;
-                    const updateInterval = estimated_seconds * 10; // Update 10 times during estimated duration
-                    const progressIncrement = 100 / (estimated_seconds * 1000 / updateInterval);
+                let progress = 0;
+                const updateInterval = estimated_seconds * 10;
+                const progressIncrement = 100 / (estimated_seconds * 1000 / updateInterval);
 
-                    const progressTimer = setInterval(() => {
-                        progress = Math.min(progress + progressIncrement, 95);
-                        updateExportProgress(progress, `Exporting ${numRows} rows...`);
-                    }, updateInterval);
+                const progressTimer = setInterval(() => {
+                    progress = Math.min(progress + progressIncrement, 95);
+                    updateExportProgress(progress, `Exporting ${numRows} rows...`);
+                }, updateInterval);
 
-                    // Perform the actual export
-                    const response = await fetch('{% url "contracts:export_contract_log_xlsx" %}?' + new URLSearchParams(window.location.search));
-                    clearInterval(progressTimer);
+                const response = await fetch('{% url "contracts:export_contract_log_xlsx" %}?' + new URLSearchParams(window.location.search));
+                clearInterval(progressTimer);
 
-                    if (!response.ok) throw new Error('Export failed');
+                if (!response.ok) throw new Error('Export failed');
 
-                    const blob = await response.blob();
-                    const endTime = performance.now();
-                    const duration = ((endTime - startTime) / 1000).toFixed(1);
+                const blob = await response.blob();
+                const duration = ((performance.now() - startTime) / 1000).toFixed(1);
 
-                    // Update final progress and timing
-                    updateExportProgress(100, 'Export completed successfully');
-                    exportTime.textContent = `Export completed in ${duration} seconds`;
+                updateExportProgress(100, 'Export completed successfully');
+                exportTime.textContent = `Export completed in ${duration} seconds`;
 
-                    // Download the file
-                    const url = window.URL.createObjectURL(blob);
-                    const a = document.createElement('a');
-                    a.href = url;
-                    a.download = 'contract_log.xlsx';
-                    document.body.appendChild(a);
-                    a.click();
-                    window.URL.revokeObjectURL(url);
-                    document.body.removeChild(a);
+                const url = window.URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'contract_log.xlsx';
+                document.body.appendChild(a);
+                a.click();
+                window.URL.revokeObjectURL(url);
+                document.body.removeChild(a);
 
-                    // Keep overlay visible for 2 more seconds to show completion
-                    setTimeout(() => {
-                        loadingOverlay.classList.add('hidden');
-                        exportStats.classList.add('hidden');
-                    }, 2000);
-
-                } else {
-                    throw new Error('Could not get export estimate');
-                }
-            } catch (error) {
-                console.error('Export failed:', error);
-                updateExportProgress(100, 'Export failed');
-                exportTime.textContent = 'An error occurred during export';
                 setTimeout(() => {
                     loadingOverlay.classList.add('hidden');
                     exportStats.classList.add('hidden');
                 }, 2000);
+            } else {
+                throw new Error('Could not get export estimate');
             }
+        } catch (error) {
+            console.error('Export failed:', error);
+            updateExportProgress(100, 'Export failed');
+            document.getElementById('exportTime').textContent = 'An error occurred during export';
+            setTimeout(() => {
+                loadingOverlay.classList.add('hidden');
+                document.getElementById('exportStats').classList.add('hidden');
+            }, 2000);
+        }
+    }
+
+    exportBtn.addEventListener('click', exportContractLog);
+
+    // ── Pagination: jump-to-page and per-page selector ────────────────
+    const jumpCard = document.querySelector('[data-pagination-base]');
+    if (jumpCard) {
+        const baseParams = jumpCard.dataset.paginationBase || '';
+        const numPages   = parseInt(jumpCard.dataset.numPages || '1', 10);
+        const jumpInput  = document.getElementById('jumpToPage');
+        const jumpBtn    = document.getElementById('jumpToPageBtn');
+
+        if (jumpInput && jumpBtn) {
+            function buildQuery(extra) {
+                const parts = baseParams ? [baseParams] : [];
+                if (extra) parts.push(extra);
+                return parts.length ? '?' + parts.join('&') : '';
+            }
+            jumpBtn.addEventListener('click', function () {
+                let p = parseInt(jumpInput.value, 10);
+                if (isNaN(p) || p < 1) p = 1;
+                if (p > numPages) p = numPages;
+                window.location.href = window.location.pathname + buildQuery('page=' + p);
+            });
+            jumpInput.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter') jumpBtn.click();
+            });
         }
 
-        exportBtn.addEventListener('click', exportContractLog);
-
-        // Jump to page
-        const jumpCard = document.querySelector('[data-pagination-base]');
-        if (jumpCard) {
-            const baseParams = jumpCard.dataset.paginationBase || '';
-            const numPages = parseInt(jumpCard.dataset.numPages || '1', 10);
-            const jumpInput = document.getElementById('jumpToPage');
-            const jumpBtn = document.getElementById('jumpToPageBtn');
-            if (jumpInput && jumpBtn) {
-                function buildQuery(extra) {
-                    const parts = baseParams ? [baseParams] : [];
-                    if (extra) parts.push(extra);
-                    return parts.length ? '?' + parts.join('&') : '';
-                }
-                jumpBtn.addEventListener('click', function() {
-                    let p = parseInt(jumpInput.value, 10);
-                    if (isNaN(p) || p < 1) p = 1;
-                    if (p > numPages) p = numPages;
-                    window.location.href = window.location.pathname + buildQuery('page=' + p);
-                });
-                jumpInput.addEventListener('keydown', function(e) {
-                    if (e.key === 'Enter') jumpBtn.click();
-                });
-            }
-            // Per page selector
-            const perPageSelect = document.getElementById('perPageSelect');
-            if (perPageSelect) {
-                perPageSelect.addEventListener('change', function() {
-                    const per = this.value;
-                    const q = baseParams ? baseParams + '&' : '';
-                    window.location.href = window.location.pathname + '?' + q + 'per_page=' + per + '&page=1';
-                });
-            }
+        const perPageSelect = document.getElementById('perPageSelect');
+        if (perPageSelect) {
+            perPageSelect.addEventListener('change', function () {
+                const per = this.value;
+                const q   = baseParams ? baseParams + '&' : '';
+                window.location.href = window.location.pathname + '?' + q + 'per_page=' + per + '&page=1';
+            });
         }
-    });
+    }
+
+});
 </script>
 {% endblock %}

--- a/contracts/views/contract_log_views.py
+++ b/contracts/views/contract_log_views.py
@@ -12,9 +12,129 @@ from django.conf import settings
 import sys
 from decimal import Decimal
 import time
+from datetime import date as _date_cls
 
 from STATZWeb.decorators import conditional_login_required
-from ..models import Clin, ClinAcknowledgment, ClinSplit, Supplier, ExportTiming
+from ..models import Clin, ClinAcknowledgment, ClinSplit, Supplier, ExportTiming, Buyer, ContractType
+
+
+def _apply_log_filters(clins, params, active_company):
+    """Apply all master-log GET filter params to a Clin queryset."""
+    def _d(val):
+        try:
+            return _date_cls.fromisoformat(val.strip())
+        except (ValueError, AttributeError):
+            return None
+
+    # ── existing filters ──────────────────────────────────────────────
+    search = params.get('search', '').strip()
+    if search:
+        clins = clins.filter(
+            Q(contract__contract_number__icontains=search) |
+            Q(contract__po_number__icontains=search) |
+            Q(contract__tab_num__icontains=search) |
+            Q(supplier__name__icontains=search) |
+            Q(nsn__nsn_code__icontains=search) |
+            Q(item_number__icontains=search)
+        ).distinct()
+
+    status = params.get('status', '').strip()
+    if status == 'open':
+        clins = clins.filter(
+            Q(contract__status__description='Open') &
+            Q(contract__date_closed__isnull=True)
+        )
+    elif status == 'closed':
+        clins = clins.filter(
+            Q(contract__status__description='Closed') &
+            Q(contract__date_closed__isnull=False)
+        )
+    elif status in ('canceled', 'cancelled'):
+        clins = clins.filter(contract__status__description='Canceled')
+
+    supplier = params.get('supplier', '').strip()
+    if supplier:
+        contract_ids = Clin.objects.filter(
+            supplier_id=supplier,
+            company=active_company,
+        ).values_list('contract_id', flat=True).distinct()
+        clins = clins.filter(contract_id__in=contract_ids)
+
+    # ── new column filters ────────────────────────────────────────────
+    po = params.get('po', '').strip()
+    if po:
+        clins = clins.filter(contract__po_number__icontains=po)
+
+    idiq = params.get('idiq', '').strip()
+    if idiq:
+        clins = clins.filter(contract__idiq_contract__contract_number__icontains=idiq)
+
+    contract_num = params.get('contract', '').strip()
+    if contract_num:
+        clins = clins.filter(contract__contract_number__icontains=contract_num)
+
+    buyer = params.get('buyer', '').strip()
+    if buyer:
+        clins = clins.filter(contract__buyer_id=buyer)
+
+    ctype = params.get('ctype', '').strip()
+    if ctype:
+        clins = clins.filter(contract__contract_type_id=ctype)
+
+    clin_num = params.get('clin', '').strip()
+    if clin_num:
+        clins = clins.filter(item_number__icontains=clin_num)
+
+    cage = params.get('cage', '').strip()
+    if cage:
+        clins = clins.filter(supplier__cage_code__icontains=cage)
+
+    nsn = params.get('nsn', '').strip()
+    if nsn:
+        clins = clins.filter(nsn__nsn_code__icontains=nsn)
+
+    desc = params.get('desc', '').strip()
+    if desc:
+        clins = clins.filter(nsn__description__icontains=desc)
+
+    ia = params.get('ia', '').strip()
+    if ia:
+        clins = clins.filter(ia=ia)
+
+    fob = params.get('fob', '').strip()
+    if fob:
+        clins = clins.filter(fob=fob)
+
+    # Date ranges
+    award_from = _d(params.get('award_from', ''))
+    award_to   = _d(params.get('award_to', ''))
+    if award_from:
+        clins = clins.filter(contract__award_date__gte=award_from)
+    if award_to:
+        clins = clins.filter(contract__award_date__lte=award_to)
+
+    qdd_from = _d(params.get('qdd_from', ''))
+    qdd_to   = _d(params.get('qdd_to', ''))
+    if qdd_from:
+        clins = clins.filter(supplier_due_date__gte=qdd_from)
+    if qdd_to:
+        clins = clins.filter(supplier_due_date__lte=qdd_to)
+
+    due_from = _d(params.get('due_from', ''))
+    due_to   = _d(params.get('due_to', ''))
+    if due_from:
+        clins = clins.filter(due_date__gte=due_from)
+    if due_to:
+        clins = clins.filter(due_date__lte=due_to)
+
+    ship_from = _d(params.get('ship_from', ''))
+    ship_to   = _d(params.get('ship_to', ''))
+    if ship_from:
+        clins = clins.filter(ship_date__gte=ship_from)
+    if ship_to:
+        clins = clins.filter(ship_date__lte=ship_to)
+
+    return clins
 
 
 class ContractLogView(ListView):
@@ -35,7 +155,6 @@ class ContractLogView(ListView):
         return self.paginate_by
 
     def get_queryset(self):
-        """Get the list of CLINs for this view."""
         clins = Clin.objects.filter(company=self.request.active_company).select_related(
             'contract',
             'contract__buyer',
@@ -78,78 +197,44 @@ class ContractLogView(ListView):
                 output_field=BooleanField(),
             ),
         ).order_by('contract__award_date', 'contract__po_number', 'item_number')
-        
-        # Apply filters if provided
-        search_query = self.request.GET.get('search', '')
-        status_filter = self.request.GET.get('status', '')
-        supplier_filter = self.request.GET.get('supplier', '')
-        
-        if search_query:
-            clins = clins.filter(
-                Q(contract__contract_number__icontains=search_query) |
-                Q(contract__po_number__icontains=search_query) |
-                Q(contract__tab_num__icontains=search_query) |
-                Q(supplier__name__icontains=search_query) |
-                Q(nsn__nsn_code__icontains=search_query) |
-                Q(item_number__icontains=search_query)
-            ).distinct()
-        
-        if status_filter:
-            if status_filter == 'open':
-                clins = clins.filter(
-                    Q(contract__status__description='Open') &
-                    Q(contract__date_closed__isnull=True)
-                )
-            elif status_filter == 'closed':
-                clins = clins.filter(
-                    Q(contract__status__description='Closed') &
-                    Q(contract__date_closed__isnull=False)
-                )
-            elif status_filter in ('canceled', 'cancelled'):
-                clins = clins.filter(contract__status__description='Canceled')
-        
-        if supplier_filter:
-            # Get all contract IDs that have any CLIN with the specified supplier
-            contract_ids = Clin.objects.filter(
-                supplier_id=supplier_filter
-            , company=self.request.active_company).values_list('contract_id', flat=True).distinct()
-            
-            # Filter CLINs to show all CLINs from the matched contracts
-            clins = clins.filter(contract_id__in=contract_ids)
-        
-        return clins
-    
+
+        return _apply_log_filters(clins, self.request.GET, self.request.active_company)
+
     def get(self, request, *args, **kwargs):
         # If no page is specified, calculate and redirect to the last page
         if 'page' not in request.GET:
             queryset = self.get_queryset()
             paginator = self.get_paginator(queryset, self.paginate_by)
-            # Get the URL parameters excluding the page parameter
             params = request.GET.copy()
-            # Add the last page number
             params['page'] = paginator.num_pages
-            # Redirect to the last page with all other parameters preserved
             return redirect(f"{request.path}?{params.urlencode()}")
         return super().get(request, *args, **kwargs)
-    
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        
-        # Add filter parameters to context
+
+        # Existing filter params
         context['search_query'] = self.request.GET.get('search', '')
         context['status_filter'] = self.request.GET.get('status', '')
         context['supplier_filter'] = self.request.GET.get('supplier', '')
         paginator = context.get('paginator')
         context['current_per_page'] = paginator.per_page if paginator else self.paginate_by
         context['allowed_per_page'] = self.allowed_per_page
-        # Base query string for pagination links (preserves search, status, supplier, per_page)
         params = self.request.GET.copy()
         params.pop('page', None)
         context['pagination_query_string'] = params.urlencode()
 
-        # Add suppliers list for the dropdown
+        # Dropdown data for filter sidebar
         context['suppliers'] = Supplier.objects.all().order_by('name')
-        
+        context['buyers'] = Buyer.objects.all().order_by('description')
+        context['contract_types'] = ContractType.objects.all().order_by('description')
+
+        # Pass all new filter values back for sidebar pre-population
+        for p in ['po', 'idiq', 'contract', 'buyer', 'ctype', 'clin', 'cage', 'nsn', 'desc',
+                  'ia', 'fob', 'award_from', 'award_to', 'qdd_from', 'qdd_to',
+                  'due_from', 'due_to', 'ship_from', 'ship_to']:
+            context[f'filter_{p}'] = self.request.GET.get(p, '')
+
         # Build derived status text for each CLIN (used by UI Contract Status column)
         page_obj = context.get('page_obj')
         if page_obj:
@@ -157,13 +242,11 @@ class ContractLogView(ListView):
                 parts = []
                 if getattr(clin.contract, 'status', None) and getattr(clin.contract.status, 'description', ''):
                     parts.append(clin.contract.status.description)
-                # Use first acknowledgment if present
                 ack = None
                 try:
                     ack = clin.clinacknowledgment_set.first()
                 except Exception:
                     ack = None
-                # Per business rule: add notes when flags are false/missing
                 if not (ack and ack.po_to_supplier_bool):
                     parts.append('PO NOT SENT YET;')
                 if not (ack and ack.clin_reply_bool):
@@ -178,7 +261,6 @@ class ContractLogView(ListView):
                 except Exception:
                     clin.contract_status_text = getattr(clin.contract.status, 'description', '') if getattr(clin, 'contract', None) and getattr(clin.contract, 'status', None) else ''
 
-        # Ensure paginator data is explicitly available in the template
         if self.paginate_by is not None:
             paginator = context.get('paginator')
             page_obj = context.get('page_obj')
@@ -186,7 +268,7 @@ class ContractLogView(ListView):
                 context['is_paginated'] = True
                 context['page_obj'] = page_obj
                 context['paginator'] = paginator
-        
+
         return context
 
 
@@ -194,8 +276,7 @@ class ContractLogView(ListView):
 def export_contract_log(request):
     """Export contract log to CSV with all relevant fields."""
     start_time = time.time()
-    
-    # Get all CLINs with related data
+
     clins = Clin.objects.filter(company=request.active_company).select_related(
         'contract',
         'contract__buyer',
@@ -205,82 +286,34 @@ def export_contract_log(request):
         'supplier',
         'nsn'
     ).prefetch_related(
-        'clinacknowledgment_set',  # Use prefetch_related for reverse relation
+        'clinacknowledgment_set',
     ).order_by('contract__award_date', 'contract__po_number', 'item_number')
-    
-    # Apply filters if provided
-    search_query = request.GET.get('search', '')
-    status_filter = request.GET.get('status', '')
-    supplier_filter = request.GET.get('supplier', '')
-    
-    filters_applied = {}
-    
-    if search_query:
-        filters_applied['search'] = search_query
-        clins = clins.filter(
-            Q(contract__contract_number__icontains=search_query) |
-            Q(contract__po_number__icontains=search_query) |
-            Q(contract__tab_num__icontains=search_query) |
-            Q(supplier__name__icontains=search_query) |
-            Q(nsn__nsn_code__icontains=search_query) |
-            Q(item_number__icontains=search_query)
-        ).distinct()
-    
-    if status_filter:
-        filters_applied['status'] = status_filter
-        if status_filter == 'open':
-            clins = clins.filter(
-                Q(contract__status__description='Open') &
-                Q(contract__date_closed__isnull=True)
-            )
-        elif status_filter == 'closed':
-            clins = clins.filter(
-                Q(contract__status__description='Closed') &
-                Q(contract__date_closed__isnull=False)
-            )
-        elif status_filter in ('canceled', 'cancelled'):
-            clins = clins.filter(contract__status__description='Canceled')
-    
-    if supplier_filter:
-        filters_applied['supplier'] = supplier_filter
-        # Get all contract IDs that have any CLIN with the specified supplier
-        contract_ids = Clin.objects.filter(
-            supplier_id=supplier_filter,
-            company=request.active_company,
-        ).values_list('contract_id', flat=True).distinct()
-        
-        # Filter CLINs to show all CLINs from the matched contracts
-        clins = clins.filter(contract_id__in=contract_ids)
-    
-    # Create response
+
+    clins = _apply_log_filters(clins, request.GET, request.active_company)
+    filters_applied = {k: v for k, v in request.GET.items() if k not in ('page', 'per_page') and v}
+
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename="contract_log.csv"'
-    
+
     writer = csv.writer(response)
-    # Column order aligned to the Master Log, with additions:
-    # Keep IDIQ Contract #, add CLIN #, use PO # label, and add Cage Code.
     writer.writerow([
-        'Open', 'Tab #', 'PO #', 'IDIQ Contract #', 'Contract', 'Buyer', 'Type', 'CLIN #',
+        'Open', 'PO #', 'IDIQ Contract #', 'Contract', 'Buyer', 'Type', 'CLIN #',
         'Supplier', 'Cage Code', 'Award Date', 'Contract Status', 'NSN', 'Item Description',
-        'I&A', 'PO to Sub', 'Sub Reply', 'PO to QAR', 'FOB', 'QDD', 'CDD', 'Order Qty',
-        'Ship Date', 'Ship Qty', 'Sub PO $', 'Sub Paid $', 'Terms', 'Contract $',
+        'I&A', 'PO to Sub', 'Sub Reply', 'PO to QAR', 'FOB', 'QDD', 'CDD', 'Qty / UOM',
+        'Ship Date', 'Ship Qty', 'Sub PO $', 'Sub Paid $', 'Item Value', 'Terms', 'Contract $',
         'Customer Payment $', 'Date Pay Recv', 'Plan Gross $', 'Actual Paid PPI $', 'Actual STATZ $',
         'Notes'
     ])
-    
-    # Get total count before writing rows
+
     total_rows = clins.count()
-    
     seen_contracts = set()
+
     for clin in clins:
-        # Get the first acknowledgment for the CLIN (if any)
         acknowledgment = clin.clinacknowledgment_set.first()
-        first_for_contract = False
-        if clin.contract_id not in seen_contracts:
-            first_for_contract = True
+        first_for_contract = clin.contract_id not in seen_contracts
+        if first_for_contract:
             seen_contracts.add(clin.contract_id)
-        
-        # Map first column to single-letter status like Master Log (O/C/X)
+
         if clin.contract and clin.contract.status and getattr(clin.contract.status, 'description', '') == 'Canceled':
             first_col_status = 'X'
         elif clin.contract and clin.contract.date_closed:
@@ -288,16 +321,13 @@ def export_contract_log(request):
         else:
             first_col_status = 'O'
 
-        # PO # shown (previously Sub PO # in legacy export)
         po_num = clin.po_number or clin.clin_po_num or (clin.contract.po_number if clin.contract else '')
 
-        # Special payment terms text: use Contract.special_payment_terms only (no fallback)
         terms_text = ''
         c_terms = getattr(clin.contract, 'special_payment_terms', None) if getattr(clin, 'contract', None) else None
         if c_terms is not None:
             terms_text = getattr(c_terms, 'terms', None) or getattr(c_terms, 'code', '') or ''
 
-        # Derived contract status text for export
         status_parts = []
         if clin.contract and getattr(clin.contract, 'status', None) and getattr(clin.contract.status, 'description', ''):
             status_parts.append(clin.contract.status.description)
@@ -325,9 +355,10 @@ def export_contract_log(request):
                 ).aggregate(t=Sum('split_paid'))['t'] or Decimal('0')
             )
 
+        qty_uom = f"{clin.order_qty:g} {clin.uom or 'ea'}" if clin.order_qty not in (None, '') else ''
+
         writer.writerow([
             first_col_status,
-            clin.contract.tab_num if clin.contract else '',
             po_num,
             (clin.contract.idiq_contract.contract_number if clin.contract and clin.contract.idiq_contract else ''),
             clin.contract.contract_number if clin.contract else '',
@@ -347,13 +378,14 @@ def export_contract_log(request):
             clin.fob or '',
             clin.supplier_due_date.strftime('%m/%d/%Y') if clin.supplier_due_date else '',
             clin.due_date.strftime('%m/%d/%Y') if clin.due_date else '',
-            f"{clin.order_qty:g}" if clin.order_qty not in (None, '') else '',
+            qty_uom,
             clin.ship_date.strftime('%m/%d/%Y') if clin.ship_date else '',
             f"{clin.ship_qty:g}" if clin.ship_qty not in (None, '') else '',
             f"${clin.quote_value:,.2f}" if clin.quote_value else '',
             f"${clin.paid_amount:,.2f}" if clin.paid_amount else '',
+            f"${clin.item_value:,.2f}" if clin.item_value else '',
             terms_text,
-            f"${clin.contract.contract_value:,.2f}" if clin.contract and clin.contract.contract_value else '',
+            f"${clin.contract.contract_value:,.2f}" if (first_for_contract and clin.contract and clin.contract.contract_value) else '$0.00',
             f"${clin.wawf_payment:,.2f}" if clin.wawf_payment else '',
             clin.wawf_recieved.strftime('%m/%d/%Y') if clin.wawf_recieved else '',
             f"${clin.contract.plan_gross:,.2f}" if (first_for_contract and clin.contract and clin.contract.plan_gross is not None) else '$0.00',
@@ -361,17 +393,14 @@ def export_contract_log(request):
             f"${statz_split_paid:,.2f}" if (first_for_contract and statz_split_paid) else '$0.00',
             clin.notes.count()
         ])
-    
-    # Record the export timing
+
     end_time = time.time()
-    export_time = end_time - start_time
-    
     ExportTiming.objects.create(
         row_count=total_rows,
-        export_time=export_time,
+        export_time=(end_time - start_time),
         filters_applied=filters_applied
     )
-    
+
     return response
 
 
@@ -383,14 +412,12 @@ def export_contract_log_xlsx(request):
         from openpyxl import Workbook
         from openpyxl.styles import Font, Alignment, PatternFill, Border, Side, NamedStyle
     except Exception as e:
-        # Graceful message if dependency missing
         return HttpResponse(
             f"Missing dependency for XLSX export: {e}. Please install 'openpyxl'.",
             status=500,
             content_type='text/plain'
         )
 
-    # Query same data as CSV export
     clins = Clin.objects.filter(company=request.active_company).select_related(
         'contract',
         'contract__buyer',
@@ -404,55 +431,19 @@ def export_contract_log_xlsx(request):
         'clinacknowledgment_set',
     ).order_by('contract__award_date', 'contract__po_number', 'item_number')
 
-    # Filters
-    search_query = request.GET.get('search', '')
-    status_filter = request.GET.get('status', '')
-    supplier_filter = request.GET.get('supplier', '')
+    clins = _apply_log_filters(clins, request.GET, request.active_company)
+    filters_applied = {k: v for k, v in request.GET.items() if k not in ('page', 'per_page') and v}
 
-    if search_query:
-        clins = clins.filter(
-            Q(contract__contract_number__icontains=search_query) |
-            Q(contract__po_number__icontains=search_query) |
-            Q(contract__tab_num__icontains=search_query) |
-            Q(supplier__name__icontains=search_query) |
-            Q(nsn__nsn_code__icontains=search_query) |
-            Q(item_number__icontains=search_query)
-        ).distinct()
-
-    if status_filter:
-        if status_filter == 'open':
-            clins = clins.filter(
-                Q(contract__status__description='Open') &
-                Q(contract__date_closed__isnull=True)
-            )
-        elif status_filter == 'closed':
-            clins = clins.filter(
-                Q(contract__status__description='Closed') &
-                Q(contract__date_closed__isnull=False)
-            )
-        elif status_filter in ('canceled', 'cancelled'):
-            clins = clins.filter(contract__status__description='Canceled')
-
-    if supplier_filter:
-        contract_ids = Clin.objects.filter(
-            supplier_id=supplier_filter,
-            company=request.active_company,
-        ).values_list('contract_id', flat=True).distinct()
-        clins = clins.filter(contract_id__in=contract_ids)
-
-    # Prepare workbook
     wb = Workbook()
     ws = wb.active
     ws.title = 'MASTER CONTRACT LOG Export'
 
-    # Styles
     bold = Font(bold=True)
     header_fill = PatternFill('solid', fgColor='F2F2F2')
     center = Alignment(horizontal='center', vertical='center')
     thin = Side(border_style='thin', color='DDDDDD')
     border = Border(top=thin, left=thin, right=thin, bottom=thin)
 
-    # Title rows
     company_name = getattr(getattr(request, 'active_company', None), 'name', 'STATZ Corporation')
     ws.append([company_name])
     from datetime import datetime
@@ -460,12 +451,11 @@ def export_contract_log_xlsx(request):
     ws.append([f"Government Contracting Log - Master List", '', '', f"Export @ {now.strftime('%I:%M:%S %p')}"])
     ws.append([])
 
-    # Header row
     headers = [
-        'Open', 'Tab #', 'PO #', 'IDIQ Contract #', 'Contract', 'Buyer', 'Type', 'CLIN #',
+        'Open', 'PO #', 'IDIQ Contract #', 'Contract', 'Buyer', 'Type', 'CLIN #',
         'Supplier', 'Cage Code', 'Award Date', 'Contract Status', 'NSN', 'Item Description',
-        'I&A', 'PO to Sub', 'Sub Reply', 'PO to QAR', 'FOB', 'QDD', 'CDD', 'Order Qty',
-        'Ship Date', 'Ship Qty', 'Sub PO $', 'Sub Paid $', 'Terms', 'Contract $',
+        'I&A', 'PO to Sub', 'Sub Reply', 'PO to QAR', 'FOB', 'QDD', 'CDD', 'Qty / UOM',
+        'Ship Date', 'Ship Qty', 'Sub PO $', 'Sub Paid $', 'Item Value', 'Terms', 'Contract $',
         'Customer Payment $', 'Date Pay Recv', 'Plan Gross $', 'Actual Paid PPI $', 'Actual STATZ $',
         'Notes'
     ]
@@ -477,15 +467,16 @@ def export_contract_log_xlsx(request):
         c.alignment = center
         c.border = border
 
-    # Data rows
     seen_contracts = set()
-    # 1-indexed columns matching currency fields in headers
-    money_cols = {25, 26, 28, 31, 32, 33}
+    # 1-indexed columns for currency formatting:
+    # Sub PO$(24), Sub Paid$(25), Item Value(26), Contract$(28), Customer Pay$(29),
+    # Plan Gross$(31), PPI$(32), STATZ$(33)
+    money_cols = {24, 25, 26, 28, 29, 31, 32, 33}
+
     for clin in clins:
         ack = clin.clinacknowledgment_set.first()
-        first_for_contract = False
-        if clin.contract_id not in seen_contracts:
-            first_for_contract = True
+        first_for_contract = clin.contract_id not in seen_contracts
+        if first_for_contract:
             seen_contracts.add(clin.contract_id)
 
         ppi_split_paid = Decimal('0')
@@ -504,7 +495,6 @@ def export_contract_log_xlsx(request):
                 ).aggregate(t=Sum('split_paid'))['t'] or Decimal('0')
             )
 
-        # Derived status char
         if clin.contract and clin.contract.status and getattr(clin.contract.status, 'description', '') == 'Canceled':
             status_char = 'X'
         elif clin.contract and clin.contract.date_closed:
@@ -512,7 +502,6 @@ def export_contract_log_xlsx(request):
         else:
             status_char = 'O'
 
-        # Derived status text
         parts = []
         if clin.contract and getattr(clin.contract, 'status', None) and getattr(clin.contract.status, 'description', ''):
             parts.append(clin.contract.status.description)
@@ -524,15 +513,15 @@ def export_contract_log_xlsx(request):
             parts.append('PO TO QAR NEEDED;')
         status_text = ' '.join(parts).strip()
 
-        # Terms text: only contract-level
         terms = ''
         if clin.contract and getattr(clin.contract, 'special_payment_terms', None):
             spt = clin.contract.special_payment_terms
             terms = getattr(spt, 'terms', None) or getattr(spt, 'code', '') or ''
 
+        qty_uom = f"{float(clin.order_qty):g} {clin.uom or 'ea'}" if clin.order_qty not in (None, '') else ''
+
         row = [
             status_char,
-            clin.contract.tab_num if clin.contract else '',
             (clin.po_number or clin.clin_po_num or (clin.contract.po_number if clin.contract else '')),
             (clin.contract.idiq_contract.contract_number if clin.contract and clin.contract.idiq_contract else ''),
             clin.contract.contract_number if clin.contract else '',
@@ -552,13 +541,14 @@ def export_contract_log_xlsx(request):
             clin.fob or '',
             clin.supplier_due_date.strftime('%m/%d/%Y') if clin.supplier_due_date else '',
             clin.due_date.strftime('%m/%d/%Y') if clin.due_date else '',
-            float(clin.order_qty) if clin.order_qty not in (None, '') else '',
+            qty_uom,
             clin.ship_date.strftime('%m/%d/%Y') if clin.ship_date else '',
             float(clin.ship_qty) if clin.ship_qty not in (None, '') else '',
             float(clin.quote_value) if clin.quote_value else '',
             float(clin.paid_amount) if clin.paid_amount else '',
+            float(clin.item_value) if clin.item_value else '',
             terms,
-            float(clin.contract.contract_value) if clin.contract and clin.contract.contract_value else '',
+            float(clin.contract.contract_value) if (first_for_contract and clin.contract and clin.contract.contract_value) else 0.0,
             float(clin.wawf_payment) if clin.wawf_payment else '',
             clin.wawf_recieved.strftime('%m/%d/%Y') if clin.wawf_recieved else '',
             float(clin.contract.plan_gross) if (first_for_contract and clin.contract and clin.contract.plan_gross is not None) else 0.0,
@@ -567,20 +557,19 @@ def export_contract_log_xlsx(request):
             int(clin.notes.count())
         ]
         ws.append(row)
-        # apply borders to last row
         r = ws.max_row
-        for c in range(1, len(headers)+1):
+        for c in range(1, len(headers) + 1):
             ws.cell(row=r, column=c).border = border
 
-    # Column widths and number formats
     from openpyxl.utils import get_column_letter
-    widths = [6, 8, 10, 18, 18, 14, 12, 8, 24, 10, 12, 26, 12, 24, 8, 10, 10, 10, 8, 10, 10, 10, 10, 10, 12, 12, 12, 12, 14, 14, 14, 14, 30]
+    widths = [6, 10, 18, 18, 14, 12, 8, 24, 10, 12, 26, 12, 24, 8, 10, 10, 10, 8, 10, 10, 10, 10, 10, 12, 12, 12, 12, 14, 14, 14, 14, 14, 14, 30]
     for i in range(1, len(headers) + 1):
         try:
-            w = widths[i-1] if i-1 < len(widths) else 12
+            w = widths[i - 1] if i - 1 < len(widths) else 12
             ws.column_dimensions[get_column_letter(i)].width = w
         except Exception:
             pass
+
     currency_fmt = '[$$-409]#,##0.00'
     for row in ws.iter_rows(min_row=5, min_col=1, max_col=len(headers), max_row=ws.max_row):
         for idx, cell in enumerate(row, start=1):
@@ -589,7 +578,6 @@ def export_contract_log_xlsx(request):
 
     ws.freeze_panes = 'A5'
 
-    # Build response
     from io import BytesIO
     buff = BytesIO()
     wb.save(buff)
@@ -601,15 +589,15 @@ def export_contract_log_xlsx(request):
     )
     response['Content-Disposition'] = 'attachment; filename="contract_log.xlsx"'
 
-    # Timing record
     end_time = time.time()
     ExportTiming.objects.create(
         row_count=clins.count(),
         export_time=(end_time - start_time),
-        filters_applied={'format': 'xlsx'}
+        filters_applied=filters_applied
     )
 
     return response
+
 
 @conditional_login_required
 def get_export_estimate(request):
@@ -627,12 +615,12 @@ def open_export_folder(request):
     """Open the export folder in the file explorer."""
     export_folder = os.path.join(settings.MEDIA_ROOT, 'exports')
     os.makedirs(export_folder, exist_ok=True)
-    
+
     if sys.platform == 'win32':
         os.startfile(export_folder)
-    elif sys.platform == 'darwin':  # macOS
+    elif sys.platform == 'darwin':
         subprocess.run(['open', export_folder])
-    else:  # Linux
+    else:
         subprocess.run(['xdg-open', export_folder])
-    
-    return JsonResponse({'success': True}) 
+
+    return JsonResponse({'success': True})


### PR DESCRIPTION
- Extract _apply_log_filters() helper to consolidate all filter logic
  (previously duplicated across get_queryset and both export functions)
- Add 18 new server-side filter params: po, idiq, contract, buyer, ctype,
  clin, cage, nsn, desc, ia, fob, and date ranges for award/qdd/cdd/ship
- Replace horizontal filter panel with a sliding left-sidebar drawer
  (e-commerce style) with grouped fieldsets and active-filter count badge
- Table: rename "Order Qty" → "Qty / UOM"; add Item Value column; make
  Contract $ first-CLIN-only (matching Plan Gross behaviour); remove Tab #
  from exports; update export headers and row data to match
- Sidebar auto-opens when URL contains active filters; badge shows count

https://claude.ai/code/session_019cQai2nAER6o5Q31a2apLn